### PR TITLE
Workaround: Add auth data to response body

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -46,8 +46,11 @@ module DeviseTokenAuth
 
         yield if block_given?
 
+        # Add auth data to the response body for devices that don't fully suport CORS/Exposed headers
+        @auth_header = @resource.build_auth_header(@token, @client_id)
         render json: {
-          data: @resource.token_validation_response
+          data: @resource.token_validation_response,
+          auth: @auth_header
         }
 
       elsif @resource and not (!@resource.respond_to?(:active_for_authentication?) or @resource.active_for_authentication?)


### PR DESCRIPTION
This is for devices that have trouble supporting CORS/Exposed Headers. On iOS we had an issue where it always removed any non-standard response headers, regardless of if they appeared in the exposed headers list. To work around this issue we add the auth data to the response body temporarily until ng-token-auth retrieves the necessary auth values and then removes it from the response body.
